### PR TITLE
Optionally store git metadata in RE md

### DIFF
--- a/nslsii/__init__.py
+++ b/nslsii/__init__.py
@@ -49,7 +49,7 @@ def configure_base(
     redis_ssl=False,
     redis_prefix="",
     redis_db: int = 0,
-    profile_collection_dir=None,
+    startup_dir=None,
 ):
     """
     Perform base setup and instantiation of important objects.
@@ -122,8 +122,8 @@ def configure_base(
         Set the prefix for the Redis key. Typically the endstation prefix, e.g. "arpes-". "" by default.
     redis_db : int, optional
         Set the database index for the Redis connection. Defaults to 0.
-    profile_collection_dir : Path, optional
-        None by default, path to the profile collection being used
+    startup_dir : Path, optional
+        None by default, path to the repository being used
     Returns
     -------
     names : list
@@ -315,10 +315,10 @@ def configure_base(
 
     import_star(bluesky.simulators, ns)
 
-    # store git profile-collection metadata in RE
-    if profile_collection_dir:
-        ref, branch, dirty = git_info(profile_collection_dir)
-        RE.md['profile_collection_git_metadata'] = {'ref': ref, 'branch': branch, 'dirty': dirty}
+    # store startup code git repository metadata in RE
+    if startup_dir:
+        ref, branch, dirty = git_info(startup_dir)
+        RE.md['startup_git_metadata'] = {'ref': ref, 'branch': branch, 'dirty': dirty}
 
     user_ns.update(ns)
     return list(ns)

--- a/nslsii/__init__.py
+++ b/nslsii/__init__.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import appdirs
 from IPython import get_ipython
 
-from .utils import open_redis_client
+from .utils import open_redis_client, git_info
 
 try:
     from ._version import __version__
@@ -49,6 +49,7 @@ def configure_base(
     redis_ssl=False,
     redis_prefix="",
     redis_db: int = 0,
+    profile_collection_dir=None,
 ):
     """
     Perform base setup and instantiation of important objects.
@@ -121,7 +122,8 @@ def configure_base(
         Set the prefix for the Redis key. Typically the endstation prefix, e.g. "arpes-". "" by default.
     redis_db : int, optional
         Set the database index for the Redis connection. Defaults to 0.
-
+    profile_collection_dir : Path, optional
+        None by default, path to the profile collection being used
     Returns
     -------
     names : list
@@ -312,6 +314,11 @@ def configure_base(
     import bluesky.simulators
 
     import_star(bluesky.simulators, ns)
+
+    # store git profile-collection metadata in RE
+    if profile_collection_dir:
+        ref, branch, dirty = git_info(profile_collection_dir)
+        RE.md['profile_collection_git_metadata'] = {'ref': ref, 'branch': branch, 'dirty': dirty}
 
     user_ns.update(ns)
     return list(ns)

--- a/nslsii/utils.py
+++ b/nslsii/utils.py
@@ -1,6 +1,9 @@
 import os
-from redis import Redis
+from pathlib import Path
 import socket
+import subprocess
+
+from redis import Redis
 
 redis_hosts = [
     "xf02id1-six-redis1.nsls2.bnl.gov",
@@ -98,3 +101,37 @@ def open_redis_client(
         db=redis_db,
     )
     return conn
+
+
+def git_info(git_dir: Path) -> tuple[str, str, bool] | tuple[None, None, None]:
+    """Helper function to get metadata of local git repository"""
+    cwd = Path(git_dir).resolve()
+
+    try:
+        commit = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            cwd=cwd,
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+
+        branch = subprocess.check_output(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            cwd=cwd,
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+
+        dirty = bool(subprocess.check_output(
+            ["git", "status", "--porcelain"],
+            cwd=cwd,
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip())
+
+        return commit, branch, dirty
+
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None, None, None
+        
+        


### PR DESCRIPTION
As part of an effort to have more provenance for [blop](https://github.com/bluesky/blop) agents, having the ability to link profile collection code back to an optimization run is important.

This PR adds an optional argument `profile_collection_dir` to `configure_base()` which when provided, stores the current ref, branch name, and dirty status to `RE.md`